### PR TITLE
Misc. Bugfixes

### DIFF
--- a/.idea/deploymentTargetDropDown.xml
+++ b/.idea/deploymentTargetDropDown.xml
@@ -2,21 +2,8 @@
 <project version="4">
   <component name="deploymentTargetDropDown">
     <value>
-      <entry key="app">
-        <State>
-          <targetSelectedWithDropDown>
-            <Target>
-              <type value="QUICK_BOOT_TARGET" />
-              <deviceKey>
-                <Key>
-                  <type value="VIRTUAL_DEVICE_PATH" />
-                  <value value="$USER_HOME$/.android/avd/Resizable_Experimental_API_34.avd" />
-                </Key>
-              </deviceKey>
-            </Target>
-          </targetSelectedWithDropDown>
-          <timeTargetWasSelectedWithDropDown value="2024-04-24T19:55:52.783224Z" />
-        </State>
+      <entry key="VRC RoboScout">
+        <State />
       </entry>
     </value>
   </component>

--- a/app/src/main/java/com/sunkensplashstudios/VRCRoboScout/LookupView.kt
+++ b/app/src/main/java/com/sunkensplashstudios/VRCRoboScout/LookupView.kt
@@ -373,7 +373,7 @@ fun TeamLookup(lookupViewModel: LookupViewModel, navController: NavController) {
             Box {
                 IconButton(onClick = {
                     favoriteTeams =
-                        if (lookupViewModel.number.value.isEmpty() || lookupViewModel.number.value == "229V\u200B" || !lookupViewModel.fetchedTeams.value) {
+                        if (lookupViewModel.number.value.isEmpty() || lookupViewModel.number.value == "229V\u200B") {
                             return@IconButton
                         } else if (favoriteTeams.contains(lookupViewModel.number.value.uppercase()) && !lookupViewModel.loadingTeams.value) {
                             userSettings.removeFavoriteTeam(lookupViewModel.number.value.uppercase())
@@ -381,10 +381,17 @@ fun TeamLookup(lookupViewModel: LookupViewModel, navController: NavController) {
                                 .replace("]", "")
                                 .split(", ")
                         } else {
-                            userSettings.addFavoriteTeam(lookupViewModel.number.value.uppercase())
-                            userSettings.getData("favoriteTeams", "").replace("[", "")
-                                .replace("]", "")
-                                .split(", ")
+                            // allow adding to favorites only after fetching team data
+                            if (!lookupViewModel.fetchedTeams.value) {
+                                return@IconButton
+                            }
+
+                            else {
+                                userSettings.addFavoriteTeam(lookupViewModel.number.value.uppercase())
+                                userSettings.getData("favoriteTeams", "").replace("[", "")
+                                    .replace("]", "")
+                                    .split(", ")
+                            }
                         }
                 }) {
                     if (favoriteTeams.contains(lookupViewModel.number.value.uppercase()) && lookupViewModel.number.value.isNotBlank()) {

--- a/app/src/main/java/com/sunkensplashstudios/VRCRoboScout/LookupView.kt
+++ b/app/src/main/java/com/sunkensplashstudios/VRCRoboScout/LookupView.kt
@@ -318,7 +318,7 @@ fun TeamLookup(lookupViewModel: LookupViewModel, navController: NavController) {
             TextField(
                 modifier = Modifier.sizeIn(maxWidth = 200.dp),
                 value = lookupViewModel.number.value,
-                onValueChange = { lookupViewModel.number.value = it },
+                onValueChange = { lookupViewModel.number.value = it.trim() },
                 singleLine = true,
                 interactionSource = remember { MutableInteractionSource() }
                     .also { interactionSource ->

--- a/app/src/main/java/com/sunkensplashstudios/VRCRoboScout/LookupView.kt
+++ b/app/src/main/java/com/sunkensplashstudios/VRCRoboScout/LookupView.kt
@@ -357,7 +357,7 @@ fun TeamLookup(lookupViewModel: LookupViewModel, navController: NavController) {
                     favoriteTeams =
                         if (lookupViewModel.number.value.isEmpty() || lookupViewModel.number.value == "229V\u200B" || !lookupViewModel.fetchedTeams.value) {
                             return@IconButton
-                        } else if (favoriteTeams.contains(lookupViewModel.number.value.uppercase()) && lookupViewModel.teamTextColor.value != Color.Unspecified) {
+                        } else if (favoriteTeams.contains(lookupViewModel.number.value.uppercase()) && !lookupViewModel.loadingTeams.value) {
                             userSettings.removeFavoriteTeam(lookupViewModel.number.value.uppercase())
                             userSettings.getData("favoriteTeams", "").replace("[", "")
                                 .replace("]", "")

--- a/app/src/main/java/com/sunkensplashstudios/VRCRoboScout/RoboScoutAPI.kt
+++ b/app/src/main/java/com/sunkensplashstudios/VRCRoboScout/RoboScoutAPI.kt
@@ -24,6 +24,7 @@ import org.ejml.simple.SimpleMatrix
 import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
+import java.util.concurrent.CopyOnWriteArrayList
 
 val API = RoboScoutAPI()
 val jsonWorker = Json {
@@ -159,8 +160,8 @@ class VDAEntry : MutableState<VDAEntry> {
 
 class RoboScoutAPI {
 
-    var wsCache: MutableList<WSEntry> = mutableListOf<WSEntry>()
-    var vdaCache: MutableList<VDAEntry> = mutableListOf<VDAEntry>()
+    var wsCache: CopyOnWriteArrayList<WSEntry> = CopyOnWriteArrayList<WSEntry>()
+    var vdaCache: CopyOnWriteArrayList<VDAEntry> = CopyOnWriteArrayList<VDAEntry>()
     var regionsMap: MutableMap<String, Int> = mutableMapOf<String, Int>()
     var importedWS: Boolean = false
     var importedVDA: Boolean = false
@@ -395,10 +396,8 @@ class RoboScoutAPI {
 
      fun worldSkillsFor(team: Team): WSEntry {
         return try {
-            synchronized(this.wsCache) {
-                this.wsCache.first {
-                    it.team.id == team.id
-                }
+            this.wsCache.first {
+                it.team.id == team.id
             }
         } catch (e: NoSuchElementException) {
             WSEntry()
@@ -407,10 +406,8 @@ class RoboScoutAPI {
 
      fun vdaFor(team: Team): VDAEntry {
         return try {
-            synchronized(this.vdaCache) {
-                this.vdaCache.first {
-                    it.teamNumber == team.number
-                }
+            this.vdaCache.first {
+                it.teamNumber == team.number
             }
         } catch (e: NoSuchElementException) {
             VDAEntry()

--- a/app/src/main/java/com/sunkensplashstudios/VRCRoboScout/RoboScoutAPI.kt
+++ b/app/src/main/java/com/sunkensplashstudios/VRCRoboScout/RoboScoutAPI.kt
@@ -395,8 +395,10 @@ class RoboScoutAPI {
 
      fun worldSkillsFor(team: Team): WSEntry {
         return try {
-            this.wsCache.first {
-                it.team.id == team.id
+            synchronized(this.wsCache) {
+                this.wsCache.first {
+                    it.team.id == team.id
+                }
             }
         } catch (e: NoSuchElementException) {
             WSEntry()
@@ -405,8 +407,10 @@ class RoboScoutAPI {
 
      fun vdaFor(team: Team): VDAEntry {
         return try {
-            this.vdaCache.first {
-                it.teamNumber == team.number
+            synchronized(this.vdaCache) {
+                this.vdaCache.first {
+                    it.teamNumber == team.number
+                }
             }
         } catch (e: NoSuchElementException) {
             VDAEntry()

--- a/app/src/main/java/com/sunkensplashstudios/VRCRoboScout/RootActivity.kt
+++ b/app/src/main/java/com/sunkensplashstudios/VRCRoboScout/RootActivity.kt
@@ -399,6 +399,16 @@ class RootActivity : ComponentActivity() {
 
 @Composable
 fun TabView(tabBarItems: List<TabBarItem>, navController: NavController, selectedTabIndex: Int, onSelectedTabIndexChange: (Int) -> Unit) {
+    val navBackStackEntry by navController.currentBackStackEntryAsState()
+    val currentRoute = navBackStackEntry?.destination?.route
+
+    LaunchedEffect(currentRoute) {
+        val index = tabBarItems.indexOfFirst { it.direction.route == currentRoute }
+        if (index != -1 && index != selectedTabIndex) {
+            onSelectedTabIndexChange(index)
+        }
+    }
+
     val localContext = LocalContext.current
     val userSettings = UserSettings(localContext)
     NavigationBar(

--- a/app/src/main/java/com/sunkensplashstudios/VRCRoboScout/SettingsView.kt
+++ b/app/src/main/java/com/sunkensplashstudios/VRCRoboScout/SettingsView.kt
@@ -64,6 +64,8 @@ fun SettingsView(navController: NavController) {
             )
         }
     ) { padding ->
+        var update by remember { mutableStateOf(false) }
+
         Column(
             modifier = Modifier.verticalScroll(rememberScrollState())
         ) {
@@ -242,8 +244,6 @@ fun SettingsView(navController: NavController) {
                         Row(
                             modifier = Modifier.padding(vertical = 10.dp)
                         ) {
-                            var update by remember { mutableStateOf(false) }
-
                             if (minimalistic && update) {
                                 val background = MaterialTheme.colorScheme.background
                                 MaterialTheme.colorScheme.topContainer = background
@@ -325,6 +325,7 @@ fun SettingsView(navController: NavController) {
                                     userSettings.setMinimalisticMode(true)
                                     minimalistic = true
                                     reset = true
+                                    update = true
                                 }
                             )
                         }


### PR DESCRIPTION
As I have been using the app over the past few weeks, I've run into some relatively minor bugs that this PR aims to fix:

- The button to remove a team from favorites should now work as intended
- When going back via gestures or buttons, the tab navigation bar will now properly update
- The reset appearance button in settings will now reset minimalistic mode to its default value without needing a restart
- Fixed being able to enter spaces in team lookup (theoretically other characters can be removed too if desired later)
- Fixed the "229V" placeholder text and the "Event Name" placeholder text to appear properly when there is no value in their respective text fields and when their text fields are unselected, aiming to mostly prevent these text fields from "disappearing"
- (this one is pretty minor), when I was testing some of these I would occasionally get a crash due to concurrent list modifications, that should hopefully be fixed.

All of these have been tested on a release build of the app and work as intended. Thanks for the app :)